### PR TITLE
Async invocation of the PowerShell script

### DIFF
--- a/src/Owin.PowerShell/Owin.PowerShell/OwinPowerShell.cs
+++ b/src/Owin.PowerShell/Owin.PowerShell/OwinPowerShell.cs
@@ -1,27 +1,29 @@
 ﻿using System.Collections.Generic;
 using System.Management.Automation;
 using System.Threading.Tasks;
+using System.Linq;
 
 namespace Owin.PS
 {
     public class OwinPowerShell
     {
-        public Task<object> InvokeScript(string script)
+        public async Task<object> InvokeScript(string script)
         {
             var powerShell = PowerShell.
                 Create().
                 AddScript(script);
 
-            var result = powerShell.Invoke();
+            var outputs = await Task.Factory.FromAsync<PSDataCollection<PSObject>, PSInvocationSettings, PSDataCollection<PSObject>>(
+                powerShell.BeginInvoke,
+                powerShell.EndInvoke,
+                new PSDataCollection<PSObject>(),
+                new PSInvocationSettings(),
+                null,
+                TaskCreationOptions.None);
 
-            List<object> list = new List<object>();
+            List<object> results = outputs.Select(pso => pso.BaseObject).ToList();
 
-            foreach (var item in result)
-            {
-                list.Add(item.BaseObject);
-            }
-
-            return Task.FromResult<object>(list);
+            return Task.FromResult<object>(results);
         }
     }
 }


### PR DESCRIPTION
- now using PowerShell::Begin/EndInvoke to asynchronously execute the
  target script (fixes #1)
- simplified the transformation of output PSObjects to plain-old objects
  with a LINQ statement
